### PR TITLE
Add filters for date and channel to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Vosk Speech Transcription Tools
+
+This repository contains utilities for processing videos with Vosk and serving
+transcriptions through a small HTTP API.
+
+## Usage
+
+1. Generate transcriptions using `procesar_videos.py`.
+2. Start the API server:
+   ```bash
+   python api_server.py 8000
+   ```
+3. Query the API. You can filter results by `fecha` (date) and `medio` (media
+   folder name). Example:
+   ```
+   http://localhost:8000/?fecha=2025-07-22&medio=Canal13
+   ```
+   This request returns all transcripts recorded on `2025-07-22` inside the
+   `Canal13` folder.
+

--- a/api_server.py
+++ b/api_server.py
@@ -1,7 +1,19 @@
+"""Simple HTTP server that serves transcription data.
+
+The server reads ``transcripciones.json`` and exposes its contents over a
+REST-like API. Use optional ``fecha`` (``YYYY-MM-DD``) and ``medio`` query
+parameters to filter results by date and channel.
+
+Example::
+
+    http://localhost:8000/?fecha=2025-07-22&medio=Canal13
+"""
+
 import json
 import os
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from urllib.parse import urlparse, parse_qs
+from typing import Optional
 
 REGISTRO = "transcripciones.json"
 BASE_URL = "http://integra.ispaccess.conectamedia.cl:5232//Canal13/"
@@ -14,6 +26,22 @@ def cargar_registro():
     return {}
 
 
+def extraer_fecha(nombre_archivo: str) -> Optional[str]:
+    """Devuelve la fecha (YYYY-MM-DD) extraída desde el nombre del archivo."""
+
+    base = os.path.basename(nombre_archivo)
+    partes = base.split("_")
+    if len(partes) >= 3:
+        return partes[1]
+    return None
+
+
+def extraer_medio(ruta_archivo: str) -> str:
+    """Devuelve el nombre del medio (carpeta contenedora)."""
+
+    return os.path.basename(os.path.dirname(ruta_archivo))
+
+
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self):
         parsed = urlparse(self.path)
@@ -22,6 +50,8 @@ class Handler(BaseHTTPRequestHandler):
             return
         qs = parse_qs(parsed.query)
         archivo = qs.get("file", [None])[0]
+        filtro_fecha = qs.get("fecha", [None])[0]
+        filtro_medio = qs.get("medio", [None])[0]
         registro = cargar_registro()
         if archivo:
             datos = registro.get(archivo)
@@ -34,13 +64,26 @@ class Handler(BaseHTTPRequestHandler):
                 "registros": datos,
             }
         else:
+            items = registro.items()
+            if filtro_fecha:
+                items = [
+                    (k, v)
+                    for k, v in items
+                    if extraer_fecha(k) == filtro_fecha
+                ]
+            if filtro_medio:
+                items = [
+                    (k, v)
+                    for k, v in items
+                    if extraer_medio(k) == filtro_medio
+                ]
             respuesta = [
                 {
                     "file": k,
                     "url": BASE_URL + os.path.basename(k),
                     "registros": v,
                 }
-                for k, v in registro.items()
+                for k, v in items
             ]
         self.send_response(200)
         self.send_header("Content-Type", "application/json; charset=utf-8")


### PR DESCRIPTION
## Summary
- support `fecha` and `medio` filters in the API server
- document example query in new README
- clean unused imports

## Testing
- `python -m py_compile api_server.py generador_audio.py procesar_videos.py`


------
https://chatgpt.com/codex/tasks/task_e_68802b8430f0832fa2e9e64d3353e869