### PR TITLE
Include date field in transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Vosk Speech Transcription Tools
 
 This repository contains utilities for processing videos with Vosk and serving
-transcriptions through a small HTTP API.
+transcriptions through a small HTTP API. Each transcription block now includes
+the keys `inicio`, `fin`, `fecha` and `texto`.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- include `fecha` in each transcription block produced by `generador_audio.py`
- document new `fecha` field in README

## Testing
- `python -m py_compile api_server.py procesar_videos.py generador_audio.py`

------
https://chatgpt.com/codex/tasks/task_e_6880abc55930832fb83fb6617c56afe5