### PR TITLE
Include medio in transcription output

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains utilities for processing videos with Vosk and serving
 transcriptions through a small HTTP API. Each transcription block now includes
-the keys `inicio`, `fin`, `fecha` and `texto`.
+the keys `inicio`, `fin`, `fecha`, `texto` and `medio`.
 
 ## Usage
 
@@ -12,7 +12,8 @@ the keys `inicio`, `fin`, `fecha` and `texto`.
    python api_server.py 8000
    ```
 3. Query the API. You can filter results by `fecha` (date) and `medio` (media
-   folder name). The server now returns clear error messages when
+   folder name). Each transcription block also records the `medio` it belongs
+   to. The server now returns clear error messages when
    `transcripciones.json` is missing or a video has no transcription.
    Example:
    ```

--- a/generador_audio.py
+++ b/generador_audio.py
@@ -18,6 +18,8 @@ def extraer_hora_desde_nombre(nombre_archivo):
     )
 
 def procesar_audio_con_pausas(archivo_video, modelo_path="vosk-model-es-0.42"):
+    """Devuelve la transcripción en bloques con información de tiempo y medio."""
+
     wav_temp = "temp.wav"
     subprocess.run(["ffmpeg", "-y", "-i", archivo_video, "-ar", "16000", "-ac", "1", "-f", "wav", wav_temp],
                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
@@ -29,6 +31,7 @@ def procesar_audio_con_pausas(archivo_video, modelo_path="vosk-model-es-0.42"):
 
     hora_inicio = extraer_hora_desde_nombre(archivo_video)
     fecha = hora_inicio.strftime("%Y-%m-%d")
+    medio = os.path.basename(os.path.dirname(archivo_video))
     palabras = []
 
     while True:
@@ -63,6 +66,7 @@ def procesar_audio_con_pausas(archivo_video, modelo_path="vosk-model-es-0.42"):
                         hora_inicio + timedelta(seconds=actual["fin"])
                     ).strftime("%H:%M:%S.%f")[:-3],
                     "fecha": fecha,
+                    "medio": medio,
                 }
                 bloques.append(bloque)
                 actual = {"inicio": start, "texto": ""}
@@ -82,6 +86,7 @@ def procesar_audio_con_pausas(archivo_video, modelo_path="vosk-model-es-0.42"):
                     hora_inicio + timedelta(seconds=actual["fin"])
                 ).strftime("%H:%M:%S.%f")[:-3],
                 "fecha": fecha,
+                "medio": medio,
             }
         )
 


### PR DESCRIPTION
## Summary
- capture the media folder name in `generador_audio.py`
- return `medio` with each transcription block
- document the new `medio` field in README

## Testing
- `python -m py_compile generador_audio.py procesar_videos.py api_server.py`

------
https://chatgpt.com/codex/tasks/task_e_6880b866e0e0832fb0db2957c9984eea