### PR TITLE
Fix date parsing from video filenames

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -39,9 +39,9 @@ def cargar_registro():
 def extraer_fecha(nombre_archivo: str) -> Optional[str]:
     """Devuelve la fecha (YYYY-MM-DD) extraída desde el nombre del archivo."""
 
-    base = os.path.basename(nombre_archivo)
+    base, _ = os.path.splitext(os.path.basename(nombre_archivo))
     partes = base.split("_")
-    if len(partes) >= 3:
+    if len(partes) >= 2:
         return partes[1]
     return None
 

--- a/generador_audio.py
+++ b/generador_audio.py
@@ -10,12 +10,13 @@ PAUSA_MAX = 0.5  # segundos para cortar frase
 def extraer_hora_desde_nombre(nombre_archivo):
     """Devuelve la fecha y hora como :class:`datetime` a partir del nombre."""
 
-    partes = os.path.basename(nombre_archivo).split("_")
-    fecha_str = partes[1]  # "YYYY-MM-DD"
-    hora_str = partes[2]  # "21-00-08.mp4"
-    return datetime.strptime(
-        f"{fecha_str} {hora_str.replace('.mp4', '')}", "%Y-%m-%d %H-%M-%S"
-    )
+    base, _ = os.path.splitext(os.path.basename(nombre_archivo))
+    partes = base.split("_")
+    if len(partes) < 3:
+        raise ValueError(f"Nombre de archivo invalido: {nombre_archivo}")
+    fecha_str = partes[1]
+    hora_str = partes[2]
+    return datetime.strptime(f"{fecha_str} {hora_str}", "%Y-%m-%d %H-%M-%S")
 
 def procesar_audio_con_pausas(archivo_video, modelo_path="vosk-model-es-0.42"):
     """Devuelve la transcripción en bloques con información de tiempo y medio."""


### PR DESCRIPTION
## Summary
- make date extraction robust by using `os.path.splitext`
- update API helper to match the new extraction logic

## Testing
- `python -m py_compile api_server.py generador_audio.py procesar_videos.py`


------
https://chatgpt.com/codex/tasks/task_e_6880c8040dd0832f9b811b6a31435e91