### PR TITLE
Add support for OGG audio files

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ the keys `inicio`, `fin`, `fecha`, `texto` and `medio`.
 
 ## Usage
 
-1. Generate transcriptions using `procesar_videos.py`. Only `mp4` videos
-   are processed. The transcription helper `generador_audio.py` also only
-   accepts MP4 input files.
-   Only videos recorded in the last 24 hours are considered for
-   transcription.
+1. Generate transcriptions using `procesar_videos.py`. Files in `mp4` or
+   `ogg` format are processed. The transcription helper `generador_audio.py`
+   accepts both MP4 and OGG inputs. Only videos recorded in the last
+   24 hours are considered for transcription.
 2. Start the API server:
    ```bash
    python api_server.py 8000

--- a/procesar_videos.py
+++ b/procesar_videos.py
@@ -1,9 +1,9 @@
 """Procesa múltiples videos generando un archivo JSON con las transcripciones.
 
-El script recorre una carpeta que contiene archivos MP4 con un nombre de la
-forma::
+El script recorre una carpeta que contiene archivos MP4 u OGG con un nombre de
+la forma::
 
-   <id>_YYYY-MM-DD_HH-MM-SS.mp4
+   <id>_YYYY-MM-DD_HH-MM-SS.<ext>
 
 Para cada archivo se invoca ``generador_audio.procesar_audio_con_pausas`` y se
 almacena la lista de bloques devuelta. El resultado completo se guarda en
@@ -80,7 +80,9 @@ def obtener_pendientes(carpeta: str, procesados: Dict[str, List[dict]]) -> list[
     """
 
     todos = [
-        os.path.join(carpeta, f) for f in os.listdir(carpeta) if f.endswith(".mp4")
+        os.path.join(carpeta, f)
+        for f in os.listdir(carpeta)
+        if f.lower().endswith((".mp4", ".ogg"))
     ]
     todos.sort()
 


### PR DESCRIPTION
## Summary
- Allow OGG or MP4 inputs in `generador_audio.procesar_audio_con_pausas`
- Process `.ogg` files in batch script and docs

## Testing
- `python -m py_compile generador_audio.py procesar_videos.py api_server.py`


------
https://chatgpt.com/codex/tasks/task_e_6899faa8a550832f8fabdee6c0ce60bf